### PR TITLE
[FIX] get_db : missing return after db creation with forced template name

### DIFF
--- a/src/bin/get_db/get_db.py
+++ b/src/bin/get_db/get_db.py
@@ -107,6 +107,7 @@ def main_bs(cr, args, db_list):
     if force_template:
         # use force_template and exit
         create_from_template(cr, db_name, force_template)
+        return True
 
     if is_openupgrade_migration:
         # template should be: project_name_major-to_migrate_template


### PR DESCRIPTION
Else, you will end up with an error "la base de données « XXX » existe déjà" because the script tries to create it twice 