### PR TITLE
[FIX] Add stage, for migration only, to publish the database that wil…

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -283,9 +283,12 @@ publish_db:
   script:
     - cd ~gitlab-runner/builds/${AK_WORKING_DIR}
     - docker compose down
-    - NEXT_VERSION="$(pysemver bump major $MAIN_BRANCH.0)"
-    # replace . by - in version...
-    - ODOO_VERSION=${NEXT_VERSION//./-}
+    # split by . and get first result in MAJOR, second in MINOR, rest in last var
+    - IFS='.' read -r MAJOR MINOR DUMMY <<< "$MAIN_BRANCH"
+    # increment version for next migration
+    - ((MAJOR+=1))
+    # sanitize version with dash to be complient with get_db.py
+    - ODOO_VERSION=${MAJOR}-${MINOR}
     - export TARGET_DB_NAME=${BUILD_NAME}_${ODOO_VERSION}_to_migrate_template
     - export FORCE_TEMPLATE="--force_template $BUILD_NAME"
     - docker compose --profile db run bedrock dropdb --force --if-exists $TARGET_DB_NAME

--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -278,6 +278,28 @@ update_db:
       "migration.log",
     ]
 
+publish_db:
+  stage: migrate
+  script:
+    - cd ~gitlab-runner/builds/${AK_WORKING_DIR}
+    - docker compose down
+    - NEXT_VERSION="$(pysemver bump major $MAIN_BRANCH.0)"
+    # replace . by - in version...
+    - ODOO_VERSION=${NEXT_VERSION//./-}
+    - export TARGET_DB_NAME=${BUILD_NAME}_${ODOO_VERSION}_to_migrate_template
+    - export FORCE_TEMPLATE="--force_template $BUILD_NAME"
+    - docker compose --profile db run bedrock dropdb --force --if-exists $TARGET_DB_NAME
+    - docker compose --profile db run bedrock odoo/get_db.py $TARGET_DB_NAME $MAIN_BRANCH $CI_PROJECT_NAME $FORCE_TEMPLATE
+  needs:
+      # refresh_db do a docker compose stop, we don't want to be halted
+      # if this job start sooner
+      # optional true, let us the ability to run if refresh_db is not in
+      # the pipleline
+      # if we don't refresh (get a new one) the db, we still update the db
+    - job: "update_db"
+  rules:
+    - if: $AK_IS_MR == "true" && $CI_MERGE_REQUEST_LABELS =~ /migration/
+    - if: $AK_IS_MAJOR_BRANCH == "true" && $AK_DO_OPENUPGRADE_MIGRATION == "true"
 
 quality:
   stage: test
@@ -378,6 +400,8 @@ review:
       optional: true
     - job: "build"
       optional: true
+    - job: "publish_db"
+      optional: true
   rules:
     - if: $AK_IS_MR == "true"
 
@@ -421,6 +445,8 @@ review_preprod:
     - job: "update_db"
       optional: true
     - job: "build"
+      optional: true
+    - job: "publish_db"
       optional: true
 
 prepare_release:

--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -289,7 +289,7 @@ publish_db:
     - ((MAJOR+=1))
     # sanitize version with dash to be complient with get_db.py
     - ODOO_VERSION=${MAJOR}-${MINOR}
-    - export TARGET_DB_NAME=${BUILD_NAME}_${ODOO_VERSION}_to_migrate_template
+    - export TARGET_DB_NAME=${CI_PROJECT_NAME}_${ODOO_VERSION}_to_migrate_template
     - export FORCE_TEMPLATE="--force_template $BUILD_NAME"
     - docker compose --profile db run bedrock dropdb --force --if-exists $TARGET_DB_NAME
     - docker compose --profile db run bedrock odoo/get_db.py $TARGET_DB_NAME $MAIN_BRANCH $CI_PROJECT_NAME $FORCE_TEMPLATE


### PR DESCRIPTION
…l be used by openupgrade for next version

@hparfr 
Just sharing it here what I started. Similar with what you did, main diff beeing where I do it (before review)
Also, I think it won't work, because to use pysemver, we have to add ".0" so we have something like 15.0.0 which is transformed to 15-0-0.
But in get_db, I think we'll have just "15-0" so the database name won't match...
Beside that, I think it works.
The main downside for me, is the sanitizing of the version/branch name which is done differently, once in python in get_db and once in bash, here (and here, it is not so robust as in the get_db.py `sanitize_branch_name`

Anyway, I leave this here until we decide which way we go!