### PR TITLE
add virtualenv files to .gitignore

### DIFF
--- a/src/.gitignore.jinja
+++ b/src/.gitignore.jinja
@@ -6,3 +6,11 @@
 .home
 *.~lock*  # libreoffice may generate these files while opening file
 /.copier-answers-personal.yml
+
+# virtualenv files:
+/odoo/bin
+/odoo/include
+/odoo/lib
+/odoo/lib64
+/odoo/scripts
+/odoo/share


### PR DESCRIPTION
when working with virtualenv (possibly for local dev), one might want to create a project specific virtualenv.
To mimic how it's done in the base Bedrock Acsone image, one might then create it in the odoo folder [1]:

`python -m virtualenv odoo`

When this is done, the virtualenv files would suddenly pollute the git repo/git status. This .gitignore change avoids that.


[1] https://github.com/acsone/odoo-bedrock/blob/master/Dockerfile-16.0#L35