### PR TITLE
FIX module project name version

### DIFF
--- a/src/odoo/local-src/{{ project_name }}/__manifest__.py.jinja
+++ b/src/odoo/local-src/{{ project_name }}/__manifest__.py.jinja
@@ -1,7 +1,7 @@
 {
     "name": "{{ project_name }}",
     "summary": "Custom module that depend of all installed module",
-    "version": "{{ odoo_version }}.0",
+    "version": "{{ odoo_version }}.0.0.0.0",
     "development_status": "Alpha",
     "category": "Uncategorized",
     "website": "https://akretion.com",

--- a/src/odoo/local-src/{{ project_name }}/__manifest__.py.jinja
+++ b/src/odoo/local-src/{{ project_name }}/__manifest__.py.jinja
@@ -1,6 +1,6 @@
 {
     "name": "{{ project_name }}",
-    "summary": "Custom module that depend of all installed module",
+    "summary": "Custom module that depends on all installed modules",
     "version": "{{ odoo_version }}.0.0.0.0",
     "development_status": "Alpha",
     "category": "Uncategorized",


### PR DESCRIPTION
 Avoid ``` 
 File ".../odoo/modules/module.py", line 346, in load_manifest
    raise ValueError(f"Module {module}: invalid manifest") from e
```
because of missing version digits

@florian-dacosta @hparfr @bguillot @paradoxxxzero 