### PR TITLE
change secret management.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -42,6 +42,7 @@ odoo_version:
 use_secret:
   type: bool
   help: generate docker-compose dedicate file for secret
+  # only for bootstraping clea-ci|prod.secrets.docker-compose.yml
 
 org_name:
   type: str

--- a/src/.env-ci.jinja
+++ b/src/.env-ci.jinja
@@ -1,3 +1,3 @@
 ENV=ci
-COMPOSE_FILE=docker-compose.yml:{% if use_secret %}secrets.docker-compose.yml:{% endif %}ci.docker-compose.yml
+COMPOSE_FILE=docker-compose.yml:ci.docker-compose.yml:secrets.docker-compose.yml
 COMPOSE_DOCKER_CLI_BUILD=1

--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -101,6 +101,8 @@ pregetdb:
     # manage secrets
     # run only if ci.secrets.docker-compose.yml exists
     - test -f ci.secrets.docker-compose.yml && sops -d ci.secrets.docker-compose.yml > secrets.docker-compose.yml
+    # if no secrets exists, create an empty one to make .env happy
+    - test -f secrets.docker-compose.yml || touch secrets.docker-compose.yml
 
     # TODO: factorise this:
     - cp .env-ci .env

--- a/src/ci.docker-compose.yml.jinja
+++ b/src/ci.docker-compose.yml.jinja
@@ -39,10 +39,6 @@ services:
       PGUSER: ${CI_PROJECT_NAME}
       DB_HOST:
       PGHOST:
-      {% if not use_secret %}
-      PGPASSWORD: ${PGPASSWORD}
-      DB_PASSWORD: ${PGPASSWORD}
-      {% endif %}
 
       {% if branch_name != "18.0" %}
       # use pgbouncer

--- a/src/prod.docker-compose.yml.jinja
+++ b/src/prod.docker-compose.yml.jinja
@@ -54,11 +54,6 @@ services:
       DB_PORT: 6432
       PGPORT: 6432
       {% endif %}
-      {% if not use_secret %}
-      # passwords are environnment variables
-      PGPASSWORD: ${PGPASSWORD}
-      DB_PASSWORD: ${PGPASSWORD}
-      {% endif %}
 
     volumes:
       - ~/data/${COMPOSE_PROJECT_NAME}/addons:/data/odoo/addons


### PR DESCRIPTION
There should be always a secret.docker-compose.yml in prod and ci It contains oidc and data_enc keys and db credentials

In dev, basic credentials for db are in dev.docker-compose.yml

The question is now just for bootstraping a project for infra-team it may be removed in the future