### PR TITLE
[FIX] Put ADDITIONAL_ODOO_RC at the end on simple config

### DIFF
--- a/src/odoo/templates/odoo.cfg.tmpl
+++ b/src/odoo/templates/odoo.cfg.tmpl
@@ -48,7 +48,6 @@ proxy_mode = True
 ; smtp_ssl = False
 ; smtp_user = False
 unaccent = ${UNACCENT}
-${ADDITIONAL_ODOO_RC}
 
 sentry_enabled = ${SENTRY}
 sentry_environment = ${RUNNING_ENV}
@@ -59,6 +58,8 @@ sentry_traces_sample_rate = ${SENTRY_TRACES_SAMPLE_RATE}
 encryption_key_dev=${ENCRYPTION_KEY_DEV}
 encryption_key_ci=${ENCRYPTION_KEY_CI}
 encryption_key_prod=${ENCRYPTION_KEY_PROD}
+${ADDITIONAL_ODOO_RC}
+
 
 [auth_oauth_provider.Akretion]
 client_id=${AUTH_OAUTH_PROVIDER_CLIENT_ID}


### PR DESCRIPTION
Else the config set after like encryption key could be ignored if one add something like ! [ir.config_parameter]
key=value

@hparfr 