### PR TITLE
[IMP] Mount pytest config file in dev environment

### DIFF
--- a/src/dev.docker-compose.yml.jinja
+++ b/src/dev.docker-compose.yml.jinja
@@ -90,6 +90,7 @@ services:
       - ./odoo/src/setup.py:/odoo/src/setup.py
       - ./odoo/src/setup.cfg:/odoo/src/setup.cfg
       - ./odoo/src/requirements.txt:/odoo/src/requirements.txt
+      - ./odoo/pytest.ini:/odoo/pytest.ini
       # data
       - ./data/addons:/data/odoo/addons
       - ./data/filestore:/data/odoo/filestore


### PR DESCRIPTION
Take pytest.ini file into account in dev environement odoo container.
The main objectif beeing to lauch pytest on a database named "dbtest" instead of the default "db" database, which is supposed to contain a copy of the production database.