### PR TITLE
remove ADDONS_PATH from docker-compose

### DIFF
--- a/src/dev.docker-compose.yml.jinja
+++ b/src/dev.docker-compose.yml.jinja
@@ -29,10 +29,6 @@ services:
     image: ${PROJECT_NAME}
     # cache_from: ${PROJECT_NAME} # main branch
     environment:
-      # you may want a lax addons path in dev
-      # but remind that you have to list installed odoo modules in spec.yaml
-      ADDONS_PATH: /odoo/links,/odoo/local-src,/odoo/src/odoo/addons,/odoo/src/addons
-
       # sentry and bus_alt_connection are not necessary on dev
       # you may want to add queue_job here
       SERVER_WIDE_MODULES: web

--- a/src/docker-compose.yml.jinja
+++ b/src/docker-compose.yml.jinja
@@ -1,11 +1,6 @@
 services:
   odoo:
     environment:
-      # if a module is missing,
-      # - verify modules[] in spec.yaml
-      # - (re) run `ak sparse`
-      ADDONS_PATH: /odoo/links,/odoo/local-src,/odoo/src/odoo/addons
-
       # usually it's ok have a public encryption key dev
       # if you need to store secrets for all environments
       # you may create an additionnal key or generate


### PR DESCRIPTION
the original idea was to exclude useless odoo core modules by only taking /odoo/links

ak sparse, will remove these modules from the file system, achieving the same goal;
