### PR TITLE
load_db: Change psql command to use -ac option

### DIFF
--- a/src/backup/load_db.sh.jinja
+++ b/src/backup/load_db.sh.jinja
@@ -22,8 +22,8 @@ DBNAME="${1:-db}"
 dropdb $DBNAME --if-exist
 createdb $DBNAME
 pg_restore -j 8 -d $DBNAME "{{ project_name }}".dump --no-owner
-psql -d $DBNAME -c "UPDATE ir_cron set active=False"
-psql -d $DBNAME -c "UPDATE res_users SET password='admin'"
-psql -d $DBNAME -c "UPDATE ir_config_parameter SET value=4 WHERE key='auth_password_policy.minlength'"
-psql -d "$DBNAME" -c "UPDATE ir_config_parameter SET value='rgba(0,0,255,.6)' WHERE key='ribbon.background.color'"
-psql -d "$DBNAME" -c "UPDATE ir_config_parameter SET value = regexp_replace(value, '^CI', 'Local') WHERE key = 'ribbon.name';"
+psql -d $DBNAME -ac "UPDATE ir_cron set active=False"
+psql -d $DBNAME -ac "UPDATE res_users SET password='admin'"
+psql -d $DBNAME -ac "UPDATE ir_config_parameter SET value=4 WHERE key='auth_password_policy.minlength'"
+psql -d "$DBNAME" -ac "UPDATE ir_config_parameter SET value='rgba(0,0,255,.6)' WHERE key='ribbon.background.color'"
+psql -d "$DBNAME" -ac "UPDATE ir_config_parameter SET value = regexp_replace(value, '^CI', 'Local') WHERE key = 'ribbon.name';"


### PR DESCRIPTION
display executed queries in terminal


psql doc tells

>
> Input and output options:
>  -a, --echo-all           echo all input from script
>  -b, --echo-errors        echo failed commands
>  -e, --echo-queries       echo commands sent to server

I've choosen -a

==============

BEFORE

UPDATE 35
UPDATE 11
UPDATE 0
UPDATE 1
UPDATE 1


==============

AFTER

UPDATE ir_cron set active=False
UPDATE 35
UPDATE res_users SET password='admin'
UPDATE 11
UPDATE ir_config_parameter SET value=4 WHERE key='auth_password_policy.minlength'
UPDATE 0
UPDATE ir_config_parameter SET value='rgba(0,0,255,.6)' WHERE key='ribbon.background.color'
UPDATE 1
UPDATE ir_config_parameter SET value = regexp_replace(value, '^CI', 'Local') WHERE key = 'ribbon.name';
UPDATE 1
