### PR TITLE
add GitHub Actions CI templates

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -44,6 +44,11 @@ use_secret:
   help: generate docker-compose dedicate file for secret
   # only for bootstraping clea-ci|prod.secrets.docker-compose.yml
 
+use_github_ci:
+  type: bool
+  help: Set up GitHub CI workflows (pre-commit, tests)
+  default: false
+
 org_name:
   type: str
   default: Akretion

--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -1,0 +1,21 @@
+{% if use_github_ci %}
+name: Pre-Commit Checks
+
+on:
+  push:
+    branches:
+      - "{{ branch_name }}*"
+  pull_request:
+    branches:
+      - "{{ branch_name }}*"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.0
+{% endif %}

--- a/src/.github/workflows/test.yml.jinja
+++ b/src/.github/workflows/test.yml.jinja
@@ -1,0 +1,86 @@
+{% if use_github_ci %}
+name: CI
+
+on:
+  push:
+    branches:
+      - "{{ branch_name }}*"
+  pull_request:
+    branches:
+      - "{{ branch_name }}*"
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+    services:
+      postgres:
+        image: postgres:12.0
+        env:
+          POSTGRES_USER: odoo
+          POSTGRES_PASSWORD: odoo
+          POSTGRES_DB: odoo
+        ports:
+          - 5432:5432
+    env:
+      COVERAGE_INCLUDE: "{% raw %}${{ github.workspace }}/odoo/local-src/*{% endraw %}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fix file ownership
+        run: chown -R $(id -u):$(id -g) .
+
+      - name: Install Python dependencies
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          /github/home/.local/bin/uv pip install -r odoo/requirements.txt pyyaml git+https://github.com/akretion/ak
+
+      - name: Build addons paths and fetch dependencies
+        id: build_addons
+        working-directory: odoo
+        run: |
+          # 1. Download dependencies
+          ak clone && ak build
+
+          # 2. Define Base Paths
+          # /opt/odoo/addons is the Odoo core inside the OCA CI container
+          BASE_PATH="/opt/odoo/addons"
+          LOCAL_PATH="$(pwd)/local-src"
+
+          # 3. Generate External Paths dynamically
+          # List all directories in external-src, distinct them, and join with commas
+          # $(pwd) ensures we use absolute paths required by Odoo
+          EXTERNAL_PATHS=$(ls -d "$(pwd)/external-src"/* | paste -sd ",")
+
+          # 4. Combine them
+          FINAL_ADDONS_PATH="$BASE_PATH,$LOCAL_PATH,$EXTERNAL_PATHS"
+          
+          # 5. Export to GITHUB_ENV
+          # ADDONS_DIR is usually just the relative path to your modules for test discovery
+          echo "ADDONS_DIR=local-src" >> $GITHUB_ENV
+          echo "ADDONS_PATH=$FINAL_ADDONS_PATH" >> $GITHUB_ENV
+
+          # Debug print
+          echo "Calculated ADDONS_DIR: local-src"
+          echo "Calculated ADDONS_PATH: $FINAL_ADDONS_PATH"
+
+      - name: Install Odoo addons dependencies
+        working-directory: odoo
+        run: oca_install_addons
+
+      - name: Initialize test database
+        working-directory: odoo
+        run: oca_init_test_database
+
+      - name: Run Odoo tests
+        working-directory: odoo
+        run: oca_run_tests
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
+          fail_ci_if_error: true
+{% endif %}


### PR DESCRIPTION
add GitHub Actions for a CI much like the OCA one. It uses the same OCA base image and pretty much the same steps. The difference is that it uses uv instead of pip (faster) and it adds odoo/local-src and odoo/external-src to the addons-path. It uses ak build to fetch odoo/external-src and run the pre-commit and tests on the modules in odoo/local-src. The pre-commit only triggers if there is a .pre-commit-config.yaml file much like in the Gitlab CI. We could templatize this file but it's not done here.

Rational: we need a very light/cheap CI option for small/cheap projects, especially in Brazil. There is often no need for a Runbot experience on "quick start" projects with less than 5k lines of customizations and tests like the OCA ones of local-src is often enough and better than nothing.

cc @hparfr @sebastienbeau @renatonlima 