### PR TITLE
Odoo 16 uses websocket already

### DIFF
--- a/src/ci.docker-compose.yml.jinja
+++ b/src/ci.docker-compose.yml.jinja
@@ -45,7 +45,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.tls=false"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.rule=Host(`${DOMAIN}`) && PathPrefix(`{% if branch_name in ["12.0", "14.0", "15.O", "16.0"] %}/longpolling/{% else %}/websocket{% endif %}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.rule=Host(`${DOMAIN}`) && PathPrefix(`{% if branch_name in ["12.0", "14.0", "15.O"] %}/longpolling/{% else %}/websocket{% endif %}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.tls=false"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.service=${COMPOSE_PROJECT_NAME}odoo"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.service=${COMPOSE_PROJECT_NAME}odoo_long"

--- a/src/dev.docker-compose.yml.jinja
+++ b/src/dev.docker-compose.yml.jinja
@@ -51,7 +51,7 @@ services:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.rule=Host(`${DOMAIN}`) && PathPrefix(`{% if branch_name in ["12.0", "14.0", "15.O", "16.0"] %}/longpolling/{% else %}/websocket{% endif %}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.rule=Host(`${DOMAIN}`) && PathPrefix(`{% if branch_name in ["12.0", "14.0", "15.O"] %}/longpolling/{% else %}/websocket{% endif %}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.service=${COMPOSE_PROJECT_NAME}odoo"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.service=${COMPOSE_PROJECT_NAME}odoo_long"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}odoo.loadbalancer.server.port=8069"


### PR DESCRIPTION
I am no expert, but my v16 instances show me this kind of errors, so I guess the switch should concern v16 already 
```
odoo-1  |   File "/odoo/src/addons/bus/controllers/websocket.py", line 18, in websocket
odoo-1  |     return WebsocketConnectionHandler.open_connection(request)
odoo-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo-1  |   File "/odoo/src/addons/bus/websocket.py", line 830, in open_connection
odoo-1  |     raise RuntimeError(
odoo-1  | RuntimeError: Couldn't bind the websocket. Is the connection opened on the evented port (8072)?
```

