### PR TITLE
add support for intermediate_version

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -39,6 +39,13 @@ odoo_version:
   default: "{{branch_name}}"
   when: false
 
+
+is_intermediate_version:
+  # set migration stuff
+  type: bool
+  default: false
+  when: false
+
 # Remove ?
 use_secret:
   type: bool

--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -15,7 +15,7 @@ variables:
     options:
       - "true"
       - "false"
-    value: "false"
+    value: "{% if is_intermediate_version %}true{% else %}false{% endif %}"
 
 workflow:
   # Remember: gitlab stop rule evaluation at first match

--- a/src/ci.docker-compose.yml.jinja
+++ b/src/ci.docker-compose.yml.jinja
@@ -19,7 +19,9 @@ services:
       # let us know the use case.
       # sentry and bus_alt_connection don't require installation
       # bus_alt_connection is required for CI and prod
-{% if branch_name == "19.0" %}
+{% if is_intermediate_version %}
+      SERVER_WIDE_MODULES: web
+{% elif branch_name == "19.0" %}
       # for the moment sentry and bus_alt_connection not migrated yet
       SERVER_WIDE_MODULES: web,queue_job
 {% else %}
@@ -36,7 +38,7 @@ services:
       PGUSER: ${CI_PROJECT_NAME}
       DB_HOST:
       PGHOST:
-{% if branch_name != "19.0" %}
+{% if branch_name != "19.0" and not is_intermediate_version %}
       # use pgbouncer
       DB_PORT: 6432
       PGPORT: 6432


### PR DESCRIPTION
when you a migrating from v14 to v18, then 15.0, 16.0 and 17.0 are intermediate
18.0 is not intermediate; it's the end of the migration path.

intermediate do not use pgbouncer and have a simplier server-wide-modules , may be we will limit the tests / quality on intermediate versions.