### PR TITLE
fix last_git_tag.sh

### DIFF
--- a/src/bin/last_git_tag.sh
+++ b/src/bin/last_git_tag.sh
@@ -1,27 +1,29 @@
 #!/bin/bash
 set -eux -o pipefail
 
+# last_git_tag.sh MINIMUM
 # compute the "newest" git tag of the current branch
+# tag should follow semver scheme (x.y.z)
 
 # if multiples tags are found for the current commit
 # the bigger is used
 # ex 16.14.1 is bigger than 16.9.1
 
-# if no tag found argument is used as default tag
+# the tag should be bigger than MINIMUM (argument)
+# if no tag it will fallback to MINIMUM
 # or fallback to 0.0.0
+# MINIMUM should be x.y.z
 
 # version are stored as git tags
 
 # requirements:
 # git
 
-# optionnal arguments:
-# (0.0)
 if [ -z ${1:-} ]; then
   # if no arg given, default to 0.0.0
-  DEFAULT_TAG="0.0.0"
+  MINIMUM="0.0.0"
 else
-  DEFAULT_TAG=$1
+  MINIMUM=$1
 fi;
 
 # force fetch tags (especially in fetch startegy)
@@ -36,13 +38,17 @@ LATEST_CANDIDATE=$(git describe --abbrev=0 --tags)
 set -e
 if [ -z $LATEST_CANDIDATE ]; then
   # print on stderr
-  echo "No tag found, will fall back to DEFAULT_TAG" >&2
-  LATEST_TAG=${DEFAULT_TAG}
+  echo "No tag found, will fall back to MINIMUM" >&2
+  LATEST_TAG=${MINIMUM}
 else
   # if there is multiple tags on the same commit, keep the last one
   # sort -V gives 16.0.9 before 16.0.10
   # tail -n 1 gives the last line
   LATEST_TAG=$(git tag --points-at $LATEST_CANDIDATE | sort -V | tail -n 1)
+
+  # now take the max(MINIMUM, LATEST_TAG)
+  # if MINIMUM is 17.0.2 and LATEST_TAG is 16.0.4 then choose MINIMUM
+  LATEST_TAG=$(printf '%s\n%s\n' "$MINIMUM" "$LATEST_TAG" | sort -V | tail -n 1)
 fi;
 
 # current version is latest tag or commit branch name (ie 16.0)

--- a/src/bin/last_git_tag/tests.py
+++ b/src/bin/last_git_tag/tests.py
@@ -125,3 +125,38 @@ def test_current_git_tag_mulitple():
             ret = cmd()
             # strip \n
             assert ret.strip() == "16.0.4"
+
+def test_new_git_tag_mulitple():
+    # ensure to always return the last tag
+    # when switching between branches
+
+    bin = current_git_tag()
+    with local.tempdir() as tmpdir:
+        with local.cwd(tmpdir):
+            create_a_git_dir()
+            local["git"]["checkout", "-b", "16.0"]()
+            git_touch_and_add("somefile")
+            git_touch_and_add("someotherfile")
+            git_tag("16.0.3")
+
+            cmd = local[bin]["16.0.0"]
+            ret = cmd()
+            assert ret.strip() == "16.0.3"
+
+            local["git"]["checkout", "--orphan", "17.0"]()
+            git_touch_and_add("somefile")
+
+            cmd = local[bin]["17.0.0"]
+            ret = cmd()
+            # strip \n
+            assert ret.strip() == "17.0.0"
+
+            git_tag("17.2.2")
+
+            local["git"]["checkout", "-b", "18.0"]()
+            git_touch_and_add("somefile_other")
+
+            cmd = local[bin]["18.0.0"]
+            ret = cmd()
+            # strip \n
+            assert ret.strip() == "18.0.0"


### PR DESCRIPTION
fixes an issue when first tag from a new branch
we don't want to continue the last tag from previous branch