### PR TITLE
Enable `pg_stat_statements` in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,51 @@ On gitlab, mark the branch as protected
 # Bump and Migration
 
 From the gitlab pipeline, run the "publish" job to create an updated docker image
+
+# Features
+
+## `pg_stat_statements` enabled in dev environment
+
+`pg_stat_statements` allows to track statistics of SQL queries. It is very useful to
+analyze the performance of SQL queries triggered by Odoo.
+
+If not already, the extension needs to be enabled with:
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+```
+
+Then before triggering the Odoo feature you want to analyze, clear the stats:
+```sql
+SELECT pg_stat_statements_reset();
+```
+
+Launch the Odoo feature you want (e.g. a report, an SO validation...), and once it's finished, take a look on generated queries with a query such as:
+```sql
+SELECT queryid, substring(query, 1, 160) AS query,
+      calls,
+      round(total_exec_time::numeric, 2) AS total_time,
+      round(mean_exec_time::numeric, 2) AS mean_time,
+      round((100 * total_exec_time / sum(total_exec_time) OVER ())::numeric, 2) AS percentage
+FROM pg_stat_statements
+WHERE dbid IN (SELECT oid FROM pg_database WHERE datname=current_database())
+ORDER BY total_time DESC
+LIMIT 10;
+```
+
+A high number of `calls` could be an issue on Odoo/Python side (e.g. search in a loop,
+or missing cache), while a high `mean_time` could be a query badly written or a missing index.
+
+For this last issue, check the full query with:
+```sql
+SELECT query FROM pg_stat_statements WHERE queryid={QUERYID};
+```
+If there are parameters, they will be replaced by placeholders, you'll have to guess from where this query is launched in Odoo, and what parameters are used when this query is executed.
+Then launch your query prefixed with `EXPLAIN ANALYZE`:
+```sql
+EXPLAIN ANALYZE {QUERY}
+```
+This will tell you where the bottleneck could be, and up to you to find the right fix (e.g. missing index).
+
+You could use a service like [explain.dalibo.com](https://explain.dalibo.com/) to visualize the result in a nice graph.
+
+For best results, use `EXPLAIN (ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON)`.

--- a/src/dev.docker-compose.yml.jinja
+++ b/src/dev.docker-compose.yml.jinja
@@ -22,6 +22,7 @@ services:
       - .db/data:/var/lib/postgresql/data/pgdata
     networks:
       - local
+    command: postgres -c shared_preload_libraries='pg_stat_statements'
   odoo:
     build:
       context: odoo


### PR DESCRIPTION
It allows to analyze database queries performance easily with queries such as:
```sql
-- pg_stat_statements
-- Require to run PostgreSQL with ' -c shared_preload_libraries=pg_stat_statements' CLI option
-- and enable the extension on the DB with
CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-- List queries by number of calls and time consumed
SELECT queryid, substring(query, 1, 160) AS query,
      calls,
      round(total_exec_time::numeric, 2) AS total_time,
      round(mean_exec_time::numeric, 2) AS mean_time,
      round((100 * total_exec_time / sum(total_exec_time) OVER ())::numeric, 2) AS percentage
FROM pg_stat_statements
WHERE dbid IN (SELECT oid FROM pg_database WHERE datname=current_database())
ORDER BY total_time DESC
LIMIT 10;
-- Get the full query (to run EXPLAIN ANALYZE afterward on it)
SELECT query FROM pg_stat_statements WHERE queryid=%s;
-- Reset collected stats at any time with:
SELECT pg_stat_statements_reset();
```

Slow queries can then be checked in details with `EXPLAIN ANALYZE` + https://explain.dalibo.com/ 